### PR TITLE
Add a max-width to the body element and center it

### DIFF
--- a/css/init.scss
+++ b/css/init.scss
@@ -39,6 +39,8 @@ font-variant: normal;
 line-height: 1.6;
 margin: 0;
 padding: 1em;
+max-width: 100ch;
+margin: 0 auto;
 }
 
 hr {


### PR DESCRIPTION
I've added a max-width to make the content more comfortable to read on large screens. A constrained width means less 'scanning' of the eyes left and right for sighted readers, which reduces fatigue and makes content nicer to read :) 

Before:

![The text spans the full viewport width, resulting in a lot of scanning of the eyes for sighted readers](https://user-images.githubusercontent.com/6339853/108545032-2b05b580-72df-11eb-8122-2208cb71d082.png)

After:

![The text is constrained to a max-width and centered within the full viewport width, resulting in less of scanning of the eyes for sighted readers](https://user-images.githubusercontent.com/6339853/108545044-30630000-72df-11eb-80ed-3e027c56077a.png)
